### PR TITLE
adding option to create a zone from file

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,3 +1,7 @@
+Note: do not use this repository for any environment. 
+The purpose of this repository is only for learning through a Red Hat Advanced Ansible learning class.
+Use only the original repository from which this has been forked.
+
 firewalld_ext
 -------------
 


### PR DESCRIPTION
from class 20191106 ;)

### Issue type: feature request 

Adding new parameter pending:
- file; based on firewall-cmd, it is possible to create a zone from a file

### Reference
https://firewalld.org/documentation/man-pages/firewall-cmd.html

### Description
file could be: home-net.xml with following content:
```
<?xml version="1.0" encoding="utf-8"?>
<zone>
. <short>home-net</short>
. <description>For use at home with the 192.168.8.0/24 network!</description>
. <service name="ssh"/>
. <service name="mdns"/>
. <service name="dhcpv6-client"/>
</zone>
```
and the command to create the zone would be: 
```
firewall-cmd --new-zone-from-file=home-net.xml --permanent 
```
### Ansible task
```
- name: Define custom firewalld zone from file
  firewalld_zone:
    zone: clients
    file: home-net.xml
```


